### PR TITLE
190 improve arrow tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "dependencies": {
     "@emotion/react": "11.10.5",
     "@emotion/styled": "11.10.5",
-    "@graasp/chatbox": "1.0.1",
-    "@graasp/query-client": "0.1.5",
+    "@graasp/chatbox": "1.0.3",
+    "@graasp/query-client": "0.2.1",
     "@graasp/sdk": "0.4.1",
-    "@graasp/ui": "0.11.1",
+    "@graasp/ui": "github:graasp/graasp-ui#242-change-share-button-icon",
     "@mui/icons-material": "5.11.0",
     "@mui/lab": "5.0.0-alpha.119",
     "@mui/material": "5.11.8",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@graasp/chatbox": "1.0.3",
     "@graasp/query-client": "0.2.1",
     "@graasp/sdk": "0.4.1",
-    "@graasp/ui": "github:graasp/graasp-ui#242-change-share-button-icon",
+    "@graasp/ui": "0.11.2",
     "@mui/icons-material": "5.11.0",
     "@mui/lab": "5.0.0-alpha.119",
     "@mui/material": "5.11.8",

--- a/src/components/common/Tree/CustomContentTree.js
+++ b/src/components/common/Tree/CustomContentTree.js
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { useTreeItem } from '@mui/lab/TreeItem';
+import { styled } from '@mui/material';
 import Typography from '@mui/material/Typography';
+
+const StyledDiv = styled('div')({
+  // align expand arrow to top
+  alignItems: 'start !important',
+});
 
 // eslint-disable-next-line react/display-name
 const CustomContentTree = React.forwardRef((props, ref) => {
@@ -50,7 +56,7 @@ const CustomContentTree = React.forwardRef((props, ref) => {
 
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div
+    <StyledDiv
       className={clsx(className, classes.root, {
         [classes.expanded]: expanded,
         [classes.selected]: selected,
@@ -68,7 +74,7 @@ const CustomContentTree = React.forwardRef((props, ref) => {
       >
         {label}
       </Typography>
-    </div>
+    </StyledDiv>
   );
 });
 

--- a/src/components/common/Tree/CustomLabel.tsx
+++ b/src/components/common/Tree/CustomLabel.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react';
 
+import { Stack } from '@mui/material';
+
 import { ItemType, UnknownExtra } from '@graasp/sdk';
 import { ItemIcon } from '@graasp/ui';
 
@@ -10,16 +12,16 @@ type Props = {
 };
 
 const CustomLabel: FC<Props> = ({ text, extra, type }) => (
-  <div>
+  <Stack direction="row">
     <ItemIcon
       alt={`${text} icon`}
       // todo: replace this icon with a custom icon
-      sx={{ mb: '-2px', mr: 1, fontSize: '1rem' }}
+      sx={{ mt: 0.5, mr: 1, fontSize: '1rem' }}
       type={type}
       extra={extra}
     />
     {text}
-  </div>
+  </Stack>
 );
 
 export default CustomLabel;

--- a/src/components/common/Tree/Tree.js
+++ b/src/components/common/Tree/Tree.js
@@ -1,5 +1,5 @@
 /* This file is a copy of DynamicTreeView in graasp-ui.
-  A lot of features have been stripped to accomodate the simple needs of hidden items. 
+  A lot of features have been stripped to accomodate the simple needs of hidden items.
   The main goal is to add the ability to filter the item based on their tags. The Tree
   check for each element in the tree if it should be displayed (no hidden tag).
   This feature should be ported to graasp-ui. */
@@ -53,8 +53,8 @@ const DynamicTreeView = ({
       onNodeToggle={onToggle}
       expanded={expandedItems}
       aria-label="icon expansion"
-      defaultCollapseIcon={<ExpandMoreIcon />}
-      defaultExpandIcon={<ChevronRightIcon />}
+      defaultCollapseIcon={<ExpandMoreIcon sx={{ mt: 0.4 }} />}
+      defaultExpandIcon={<ChevronRightIcon sx={{ mt: 0.4 }} />}
       defaultSelected={rootId}
     >
       <TreeItem

--- a/yarn.lock
+++ b/yarn.lock
@@ -2377,23 +2377,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/sdk@npm:0.4.0":
-  version: 0.4.0
-  resolution: "@graasp/sdk@npm:0.4.0"
-  dependencies:
-    "@fastify/secure-session": 5.3.0
-    aws-sdk: 2.1310.0
-    fastify: 3.29.5
-    fluent-json-schema: 3.1.0
-    immutable: 4.2.4
-    js-cookie: 3.0.1
-    qs: 6.11.0
-    slonik: 28.1.1
-    uuid: 9.0.0
-  checksum: cf57c9e782b00c6406fbd4563e56b797bd78e8928cc4e1624601968541f6f72b7784c9d9e66bbcc46180030a7ff31f8089d8aca4ae393e57d3d5f1e8e6c614d6
-  languageName: node
-  linkType: hard
-
 "@graasp/sdk@npm:0.4.1":
   version: 0.4.1
   resolution: "@graasp/sdk@npm:0.4.1"
@@ -2417,45 +2400,6 @@ __metadata:
   dependencies:
     i18next: 21.8.1
   checksum: ca787604906c4531eded20941e968667a13f7c2fb5b4c2c03a149123ce6994ec685d1b5e125e37f420fa5d6b8edf4cbd0bb48452c554cde07d81bc0309b5dc1f
-  languageName: node
-  linkType: hard
-
-"@graasp/ui@github:graasp/graasp-ui#242-change-share-button-icon":
-  version: 0.11.1
-  resolution: "@graasp/ui@https://github.com/graasp/graasp-ui.git#commit=08e149ac68d3eb50743606dad1a1d48b65e73b24"
-  dependencies:
-    "@graasp/sdk": 0.4.0
-    clsx: 1.1.1
-    http-status-codes: 2.2.0
-    immutable: 4.2.4
-    katex: 0.16.0
-    lodash.truncate: 4.4.2
-    qs: 6.11.0
-    quill-emoji: 0.2.0
-    react-cookie-consent: 7.4.1
-    react-i18next: 11.17.0
-    react-quill: 2.0.0-beta.4
-    react-rnd: 10.3.7
-    react-text-mask: 5.4.3
-    uuid: 9.0.0
-  peerDependencies:
-    "@emotion/react": ~11.10.6
-    "@emotion/styled": ~11.10.6
-    "@mui/icons-material": ~5.11.9
-    "@mui/lab": ~5.0.0-alpha.120
-    "@mui/material": ~5.11.9
-    ag-grid-community: 28.1.1
-    ag-grid-react: 28.1.1
-    i18next: ~21.8.9
-    react: 17.0.2
-    react-dom: 17.0.2
-    react-router-dom: 6.2.2
-  peerDependenciesMeta:
-    ag-grid-community:
-      optional: true
-    ag-grid-react:
-      optional: true
-  checksum: 6763e4ef1aec40039a6faff99fec8a5fd856d3196d8c8494ff75155153805e05a04a5ac4516db7a9a57f3e4df24ec9ce2d8e49967c0f3a521a07ae2dca424c1a
   languageName: node
   linkType: hard
 
@@ -2495,6 +2439,45 @@ __metadata:
     ag-grid-react:
       optional: true
   checksum: 922cf6a9de9402178b906eda12081eb571feaecc240e621fceed3f0937b82c052c8a2700a414488f99d6da39deb7ba02b4f23343124ea4df01b55717ba17d51e
+  languageName: node
+  linkType: hard
+
+"@graasp/ui@npm:0.11.2":
+  version: 0.11.2
+  resolution: "@graasp/ui@npm:0.11.2"
+  dependencies:
+    "@graasp/sdk": 0.4.1
+    clsx: 1.1.1
+    http-status-codes: 2.2.0
+    immutable: 4.2.4
+    katex: 0.16.0
+    lodash.truncate: 4.4.2
+    qs: 6.11.0
+    quill-emoji: 0.2.0
+    react-cookie-consent: 7.4.1
+    react-i18next: 11.17.0
+    react-quill: 2.0.0-beta.4
+    react-rnd: 10.3.7
+    react-text-mask: 5.4.3
+    uuid: 9.0.0
+  peerDependencies:
+    "@emotion/react": ~11.10.6
+    "@emotion/styled": ~11.10.6
+    "@mui/icons-material": ~5.11.9
+    "@mui/lab": ~5.0.0-alpha.120
+    "@mui/material": ~5.11.9
+    ag-grid-community: 28.1.1
+    ag-grid-react: 28.1.1
+    i18next: ~21.8.9
+    react: 17.0.2
+    react-dom: 17.0.2
+    react-router-dom: 6.2.2
+  peerDependenciesMeta:
+    ag-grid-community:
+      optional: true
+    ag-grid-react:
+      optional: true
+  checksum: f0732062e011dcd45c28657eb36aeb7fdcca80cf73835f9b759c998b195ec6fe26b0e7b942dde6a090e3dd93edbd974dbc6a050a6db06d8ecd557754c2fa3ade
   languageName: node
   linkType: hard
 
@@ -9660,7 +9643,7 @@ __metadata:
     "@graasp/chatbox": 1.0.3
     "@graasp/query-client": 0.2.1
     "@graasp/sdk": 0.4.1
-    "@graasp/ui": "github:graasp/graasp-ui#242-change-share-button-icon"
+    "@graasp/ui": 0.11.2
     "@graasp/websockets": "github:graasp/graasp-plugin-websockets"
     "@mui/icons-material": 5.11.0
     "@mui/lab": 5.0.0-alpha.119

--- a/yarn.lock
+++ b/yarn.lock
@@ -2306,17 +2306,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/chatbox@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@graasp/chatbox@npm:1.0.1"
+"@graasp/chatbox@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@graasp/chatbox@npm:1.0.3"
   dependencies:
     "@emotion/react": 11.10.5
     "@emotion/styled": 11.10.5
-    "@graasp/translations": 1.3.0
-    "@graasp/ui": 0.7.1
+    "@graasp/sdk": 0.4.1
+    "@graasp/translations": 1.4.0
+    "@graasp/ui": 0.10.5
     clsx: 1.2.1
     i18next: 21.8.1
-    immutable: 4.1.0
+    immutable: 4.2.4
     lodash.truncate: 4.4.2
     moment: 2.29.4
     prism-react-renderer: 1.3.5
@@ -2324,10 +2325,11 @@ __metadata:
     react-i18next: 12.0.0
     react-markdown: 8.0.3
     react-mentions: 4.4.7
-    react-query: 3.39.2
+    react-query: 3.39.3
     react-router-dom: 6.3.0
     remark-breaks: 3.0.2
     remark-gfm: 3.0.1
+    tsc-alias: 1.8.2
   peerDependencies:
     "@mui/icons-material": "*"
     "@mui/lab": "*"
@@ -2335,26 +2337,26 @@ __metadata:
     eslint: "*"
     react: "*"
     react-dom: "*"
-  checksum: ad74ea0cb12d3eefc05f0e06e572d5596d82dde08c651cd73bca0fd85c3418a345e1dce53a25aa08495f5458225a8de25eb357f8858c9b507806e191837e3dee
+  checksum: 5e9ae617acb778628543c2697206b6409ffa5f473d5b9b89999b02850b47868681c4e156220082a98baa0bb0bd2e2f93d945d7218d86009268a76bf1c69da8a6
   languageName: node
   linkType: hard
 
-"@graasp/query-client@npm:0.1.5":
-  version: 0.1.5
-  resolution: "@graasp/query-client@npm:0.1.5"
+"@graasp/query-client@npm:0.2.1":
+  version: 0.2.1
+  resolution: "@graasp/query-client@npm:0.2.1"
   dependencies:
-    "@graasp/sdk": 0.2.0
-    "@graasp/translations": 1.1.0
+    "@graasp/sdk": 0.4.1
+    "@graasp/translations": 1.4.0
     axios: 0.27.2
     crypto-js: 4.1.1
     http-status-codes: 2.2.0
-    immutable: 4.0.0
-    qs: 6.10.3
-    react-query: 3.34.19
-    uuid: 8.3.2
+    immutable: 4.2.4
+    qs: 6.11.0
+    react-query: 3.39.3
+    uuid: 9.0.0
   peerDependencies:
     react: ^17.0.0
-  checksum: cb612d83227a6a677e2ce595ef836736dd56dc0f65efe9007a7a22aec204e79cf417807ddf3fd2275984698e8f841dd96a647f9308f6da54b9199b77ba2711e3
+  checksum: 63337026c3fe71d9a772cc5a9f2144fc523fa1682db29bb3718fb096e1a8dd9945ae32eef900a129baa32979ca5c89d9457956bf95552d06977e4f1ecd0505a2
   languageName: node
   linkType: hard
 
@@ -2409,27 +2411,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/translations@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@graasp/translations@npm:1.1.0"
+"@graasp/translations@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@graasp/translations@npm:1.4.0"
   dependencies:
     i18next: 21.8.1
-  checksum: 1d6fabce21ef205146c4f74b9b4b5dafc5969cf13a78cd7c4947a9b882cb22d48f3832ad6e20c21cc905b41b4809a1c2efa7ba629b12cd79bd2067df6ebd2f22
+  checksum: ca787604906c4531eded20941e968667a13f7c2fb5b4c2c03a149123ce6994ec685d1b5e125e37f420fa5d6b8edf4cbd0bb48452c554cde07d81bc0309b5dc1f
   languageName: node
   linkType: hard
 
-"@graasp/translations@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@graasp/translations@npm:1.3.0"
-  dependencies:
-    i18next: 21.8.1
-  checksum: 4117ea7763835caa77014e6ea3b36238fba6e6413aed5b732fc81dfd7cf214a9cb4b6331964d75d2a8918304b14e20715859bee0a672a8e81735b4727b7b7e8b
-  languageName: node
-  linkType: hard
-
-"@graasp/ui@npm:0.11.1":
+"@graasp/ui@github:graasp/graasp-ui#242-change-share-button-icon":
   version: 0.11.1
-  resolution: "@graasp/ui@npm:0.11.1"
+  resolution: "@graasp/ui@https://github.com/graasp/graasp-ui.git#commit=08e149ac68d3eb50743606dad1a1d48b65e73b24"
   dependencies:
     "@graasp/sdk": 0.4.0
     clsx: 1.1.1
@@ -2446,9 +2439,9 @@ __metadata:
     react-text-mask: 5.4.3
     uuid: 9.0.0
   peerDependencies:
-    "@emotion/react": ~11.10.5
-    "@emotion/styled": ~11.10.5
-    "@mui/icons-material": ~5.11.0
+    "@emotion/react": ~11.10.6
+    "@emotion/styled": ~11.10.6
+    "@mui/icons-material": ~5.11.9
     "@mui/lab": ~5.0.0-alpha.120
     "@mui/material": ~5.11.9
     ag-grid-community: 28.1.1
@@ -2462,13 +2455,13 @@ __metadata:
       optional: true
     ag-grid-react:
       optional: true
-  checksum: 599961399ee145e1a82555e6de86a927ae5408b4e145cc88de4eb0da3a22bc9b896b4145d44982e615a61d680b16c40832034f321d738458ea42266874c11627
+  checksum: 6763e4ef1aec40039a6faff99fec8a5fd856d3196d8c8494ff75155153805e05a04a5ac4516db7a9a57f3e4df24ec9ce2d8e49967c0f3a521a07ae2dca424c1a
   languageName: node
   linkType: hard
 
-"@graasp/ui@npm:0.7.1":
-  version: 0.7.1
-  resolution: "@graasp/ui@npm:0.7.1"
+"@graasp/ui@npm:0.10.5":
+  version: 0.10.5
+  resolution: "@graasp/ui@npm:0.10.5"
   dependencies:
     "@graasp/sdk": 0.2.0
     clsx: 1.1.1
@@ -2501,7 +2494,7 @@ __metadata:
       optional: true
     ag-grid-react:
       optional: true
-  checksum: b09b2adaa1f72b82c35dc86d2bb9fc578336c9b2858fee18302ed82c79046143ac371ce8415ad01a9385ece40e9a8634a53f9aee67d33b2e3752052b59eac5bb
+  checksum: 922cf6a9de9402178b906eda12081eb571feaecc240e621fceed3f0937b82c052c8a2700a414488f99d6da39deb7ba02b4f23343124ea4df01b55717ba17d51e
   languageName: node
   linkType: hard
 
@@ -6246,6 +6239,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^9.0.0":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: c7a3e27aa59e913b54a1bafd366b88650bc41d6651f0cbe258d4ff09d43d6a7394232a4dadd0bf518b3e696fdf595db1028a0d82c785b88bd61f8a440cecfade
+  languageName: node
+  linkType: hard
+
 "common-path-prefix@npm:^3.0.0":
   version: 3.0.0
   resolution: "common-path-prefix@npm:3.0.0"
@@ -9657,10 +9657,10 @@ __metadata:
     "@cypress/instrument-cra": 1.4.0
     "@emotion/react": 11.10.5
     "@emotion/styled": 11.10.5
-    "@graasp/chatbox": 1.0.1
-    "@graasp/query-client": 0.1.5
+    "@graasp/chatbox": 1.0.3
+    "@graasp/query-client": 0.2.1
     "@graasp/sdk": 0.4.1
-    "@graasp/ui": 0.11.1
+    "@graasp/ui": "github:graasp/graasp-ui#242-change-share-button-icon"
     "@graasp/websockets": "github:graasp/graasp-plugin-websockets"
     "@mui/icons-material": 5.11.0
     "@mui/lab": 5.0.0-alpha.119
@@ -10260,13 +10260,6 @@ __metadata:
   version: 9.0.19
   resolution: "immer@npm:9.0.19"
   checksum: f02ee53989989c287cd548a3d817fccf0bfe56db919755ee94a72ea3ae78a00363fba93ee6c010fe54a664380c29c53d44ed4091c6a86cae60957ad2cfabc010
-  languageName: node
-  linkType: hard
-
-"immutable@npm:4.0.0":
-  version: 4.0.0
-  resolution: "immutable@npm:4.0.0"
-  checksum: 4b5e9181e4d5fa06728a481835ec09c86367e5d03268666c95b522b7644ab891098022e4479a43c4c81a68f2ed82f10751ce5d33e208d7b873b6e7f9dfaf4d87
   languageName: node
   linkType: hard
 
@@ -13282,6 +13275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mylas@npm:^2.1.9":
+  version: 2.1.13
+  resolution: "mylas@npm:2.1.13"
+  checksum: f861d092137a9ac268cba88042392a5dc2a290eed5c8543954eae849d85e5961332211161d2c08c3644ad893f20dbe9de89b07f5dc027f1f92f13f2d38f4b81f
+  languageName: node
+  linkType: hard
+
 "nano-time@npm:1.0.0":
   version: 1.0.0
   resolution: "nano-time@npm:1.0.0"
@@ -14204,6 +14204,15 @@ __metadata:
   dependencies:
     find-up: ^3.0.0
   checksum: 5bac346b7c7c903613c057ae3ab722f320716199d753f4a7d053d38f2b5955460f3e6ab73b4762c62fd3e947f58e04f1343e92089e7bb6091c90877406fcd8c8
+  languageName: node
+  linkType: hard
+
+"plimit-lit@npm:^1.2.6":
+  version: 1.5.0
+  resolution: "plimit-lit@npm:1.5.0"
+  dependencies:
+    queue-lit: ^1.5.0
+  checksum: a956e4e5e515a980403ca840b00c9e2381710a3a30e60e0e38f76b7842b24a345c9e59ef03568cb5925b4e9cdf67c088008148febec59e55bd47d1cb4003b024
   languageName: node
   linkType: hard
 
@@ -15307,15 +15316,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.10.3":
-  version: 6.10.3
-  resolution: "qs@npm:6.10.3"
-  dependencies:
-    side-channel: ^1.0.4
-  checksum: 0fac5e6c7191d0295a96d0e83c851aeb015df7e990e4d3b093897d3ac6c94e555dbd0a599739c84d7fa46d7fee282d94ba76943983935cf33bba6769539b8019
-  languageName: node
-  linkType: hard
-
 "qs@npm:6.10.5":
   version: 6.10.5
   resolution: "qs@npm:6.10.5"
@@ -15354,6 +15354,13 @@ __metadata:
   version: 2.2.0
   resolution: "querystringify@npm:2.2.0"
   checksum: 5641ea231bad7ef6d64d9998faca95611ed4b11c2591a8cae741e178a974f6a8e0ebde008475259abe1621cb15e692404e6b6626e927f7b849d5c09392604b15
+  languageName: node
+  linkType: hard
+
+"queue-lit@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "queue-lit@npm:1.5.0"
+  checksum: 2e714b74072e1be9bd76356710af1d3b03763859f466a10ed74f36b5ccc524dbd0d299239adfc5cbd3a4a416c5fc69cf4af34f13ef4f95f6da70cad12cb79771
   languageName: node
   linkType: hard
 
@@ -15702,24 +15709,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-query@npm:3.34.19":
-  version: 3.34.19
-  resolution: "react-query@npm:3.34.19"
-  dependencies:
-    "@babel/runtime": ^7.5.5
-    broadcast-channel: ^3.4.1
-    match-sorter: ^6.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 765bec81e521a78ef04a8feb6710041ce838ef82bf6e1d35c7e9327cc242b232b242fd89f3604adf6747dce2df055d12b15e8e4208687cc5eb493c1c0bf71d34
-  languageName: node
-  linkType: hard
-
 "react-query@npm:3.39.2":
   version: 3.39.2
   resolution: "react-query@npm:3.39.2"
@@ -15735,6 +15724,24 @@ __metadata:
     react-native:
       optional: true
   checksum: 83b199e66af28ab67ec4d22e51da42f02447186623db926b75d27a1c09a3383da6ddc9e5b83d82578fac7abdba7e6f265aecbffdb91db61981950d3d59409346
+  languageName: node
+  linkType: hard
+
+"react-query@npm:3.39.3":
+  version: 3.39.3
+  resolution: "react-query@npm:3.39.3"
+  dependencies:
+    "@babel/runtime": ^7.5.5
+    broadcast-channel: ^3.4.1
+    match-sorter: ^6.0.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: d2de6a0992dbf039ff2de564de1ae6361f8ac7310159dae42ec16f833b79c05caedced187235c42373ac331cc5f2fe9e2b31b14ae75a815e86d86e30ca9887ad
   languageName: node
   linkType: hard
 
@@ -18038,6 +18045,22 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
+  languageName: node
+  linkType: hard
+
+"tsc-alias@npm:1.8.2":
+  version: 1.8.2
+  resolution: "tsc-alias@npm:1.8.2"
+  dependencies:
+    chokidar: ^3.5.3
+    commander: ^9.0.0
+    globby: ^11.0.4
+    mylas: ^2.1.9
+    normalize-path: ^3.0.0
+    plimit-lit: ^1.2.6
+  bin:
+    tsc-alias: dist/bin/index.js
+  checksum: d3a45982d521bb4550a71c291028cf819ee5a6e2e3c0eb3dfe36886f0f4e265a4dbf589dbcebb2e03215695a9081974715a543100176caed389e9d32c3ba0c50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR improves the arrow and folder icon placement in the tree view.
The video shows that long title now align overflowing lines at the same column as the start of the text.
Arrows are also aligned with the first line of the text.

https://user-images.githubusercontent.com/39373170/220462981-e7b17552-683b-4b63-b923-63d15be750c1.mov

In-fine, the tree view should be improved with suggestions from #168. In this PR I make necessary small changes.

I also use the version of `@graasp/ui` with the empty document placeholder bug fix #158.

closes #190 
closes #166 
closes #158 
