### PR TITLE
181 fix overflow of card title

### DIFF
--- a/src/components/common/FolderButton.js
+++ b/src/components/common/FolderButton.js
@@ -20,6 +20,8 @@ const StyledButton = styled('button')({
   margin: 0,
   border: 0,
   background: 'transparent',
+  textOverflow: 'ellipsis',
+  maxWidth: '100%',
 
   '&:hover': {
     cursor: 'pointer',


### PR DESCRIPTION
Closes #181 - unless the whole card should be made clickable.

Should pinned files also be clickable? Right now I don't think they are