### PR TITLE
fix: improve hidden pdf display

### DIFF
--- a/src/modules/common/HiddenWrapper.tsx
+++ b/src/modules/common/HiddenWrapper.tsx
@@ -9,6 +9,8 @@ import { buildHiddenWrapperId } from '@/config/selectors';
 export const HIDDEN_STYLE = {
   backgroundColor: '#eee',
   color: 'rgba(0, 0, 0, 0.3)',
+  padding: '16px',
+  opacity: '0.5',
 };
 
 const StyledBox = styled(Box, {


### PR DESCRIPTION
This PR should improve the display of hidden pdfs.

I added padding to the hidden wrapper, so the pdf is not tight with the wrapper.
I also set the opacity to 0.5 so the whole pdf is less present.

Bellow is a screenshot of the result

<img width="890" alt="Screenshot 2023-09-20 at 10 35 18" src="https://github.com/graasp/graasp-player/assets/39373170/4f7de06c-8a3d-4a5e-8b70-5aaba916e934">

