### PR TITLE
fix: do not show hidden items to admin and writers

### DIFF
--- a/cypress/e2e/hidden.cy.ts
+++ b/cypress/e2e/hidden.cy.ts
@@ -1,8 +1,5 @@
 import { buildMainPath } from '../../src/config/paths';
-import {
-  buildDocumentId,
-  buildHiddenWrapperId,
-} from '../../src/config/selectors';
+import { buildDocumentId } from '../../src/config/selectors';
 import {
   FOLDER_WITH_HIDDEN_ITEMS,
   PUBLIC_FOLDER_WITH_HIDDEN_ITEMS,
@@ -18,17 +15,13 @@ describe('Hidden Items', () => {
     const parent = FOLDER_WITH_HIDDEN_ITEMS.items[0];
     cy.visit(buildMainPath({ rootId: parent.id }));
 
-    cy.get(
-      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[1].id, false)}`,
-    ).should('exist');
-
-    // hidden document should not be displayed when in public
+    // hidden document should not be displayed
+    cy.get(`#${buildDocumentId(FOLDER_WITH_HIDDEN_ITEMS.items[1].id)}`).should(
+      'be.visible',
+    );
     cy.get(`#${buildDocumentId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id)}`).should(
       'not.exist',
     );
-    cy.get(
-      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id, true)}`,
-    ).should('not.exist');
   });
 
   it("Don't display Hidden items when viewing as writer", () => {
@@ -40,17 +33,13 @@ describe('Hidden Items', () => {
     const parent = FOLDER_WITH_HIDDEN_ITEMS.items[0];
     cy.visit(buildMainPath({ rootId: parent.id }));
 
-    cy.get(
-      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[1].id, false)}`,
-    ).should('exist');
-
-    // hidden document should not be displayed when in public
+    cy.get(`#${buildDocumentId(FOLDER_WITH_HIDDEN_ITEMS.items[1].id)}`).should(
+      'be.visible',
+    );
+    // hidden document should not be displayed
     cy.get(`#${buildDocumentId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id)}`).should(
       'not.exist',
     );
-    cy.get(
-      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id, true)}`,
-    ).should('not.exist');
   });
 
   it("Don't display Hidden items when viewing as reader", () => {
@@ -62,17 +51,13 @@ describe('Hidden Items', () => {
     const parent = FOLDER_WITH_HIDDEN_ITEMS.items[0];
     cy.visit(buildMainPath({ rootId: parent.id }));
 
-    cy.get(
-      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[1].id, false)}`,
-    ).should('exist');
-
-    // hidden document should not be displayed when in public
+    cy.get(`#${buildDocumentId(FOLDER_WITH_HIDDEN_ITEMS.items[1].id)}`).should(
+      'be.visible',
+    );
+    // hidden document should not be displayed
     cy.get(`#${buildDocumentId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id)}`).should(
       'not.exist',
     );
-    cy.get(
-      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id, true)}`,
-    ).should('not.exist');
   });
 
   it("Don't display Hidden items when viewing as public", () => {
@@ -85,21 +70,11 @@ describe('Hidden Items', () => {
     cy.visit(buildMainPath({ rootId: parent.id }));
 
     cy.get(
-      `#${buildHiddenWrapperId(
-        PUBLIC_FOLDER_WITH_HIDDEN_ITEMS.items[1].id,
-        false,
-      )}`,
-    ).should('exist');
-
-    // hidden document should not be displayed when in public
+      `#${buildDocumentId(PUBLIC_FOLDER_WITH_HIDDEN_ITEMS.items[1].id)}`,
+    ).should('be.visible');
+    // hidden document should not be displayed
     cy.get(
       `#${buildDocumentId(PUBLIC_FOLDER_WITH_HIDDEN_ITEMS.items[2].id)}`,
-    ).should('not.exist');
-    cy.get(
-      `#${buildHiddenWrapperId(
-        PUBLIC_FOLDER_WITH_HIDDEN_ITEMS.items[2].id,
-        true,
-      )}`,
     ).should('not.exist');
   });
 });

--- a/cypress/e2e/hidden.cy.ts
+++ b/cypress/e2e/hidden.cy.ts
@@ -10,7 +10,7 @@ import {
 import { MEMBERS } from '../fixtures/members';
 
 describe('Hidden Items', () => {
-  it('Display Hidden items with hidden wrapper', () => {
+  it("Don't display Hidden items when viewing as admin", () => {
     cy.setUpApi({
       items: FOLDER_WITH_HIDDEN_ITEMS.items,
     });
@@ -18,18 +18,39 @@ describe('Hidden Items', () => {
     const parent = FOLDER_WITH_HIDDEN_ITEMS.items[0];
     cy.visit(buildMainPath({ rootId: parent.id }));
 
-    cy.wait(['@getCurrentMember', '@getItem', '@getItemTags']);
-    cy.get(`#${buildDocumentId(FOLDER_WITH_HIDDEN_ITEMS.items[1].id)}`).should(
-      'exist',
+    cy.get(
+      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[1].id, false)}`,
+    ).should('exist');
+
+    // hidden document should not be displayed when in public
+    cy.get(`#${buildDocumentId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id)}`).should(
+      'not.exist',
     );
-    // hidden item should have wrapper
     cy.get(
       `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id, true)}`,
-    );
-    // hidden elements should not be shown in the navigation
+    ).should('not.exist');
+  });
+
+  it("Don't display Hidden items when viewing as writer", () => {
+    cy.setUpApi({
+      currentMember: MEMBERS.CEDRIC,
+      items: FOLDER_WITH_HIDDEN_ITEMS.items,
+    });
+
+    const parent = FOLDER_WITH_HIDDEN_ITEMS.items[0];
+    cy.visit(buildMainPath({ rootId: parent.id }));
+
     cy.get(
-      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[3].id, true)}`,
+      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[1].id, false)}`,
+    ).should('exist');
+
+    // hidden document should not be displayed when in public
+    cy.get(`#${buildDocumentId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id)}`).should(
+      'not.exist',
     );
+    cy.get(
+      `#${buildHiddenWrapperId(FOLDER_WITH_HIDDEN_ITEMS.items[2].id, true)}`,
+    ).should('not.exist');
   });
 
   it("Don't display Hidden items when viewing as reader", () => {

--- a/cypress/fixtures/items.ts
+++ b/cypress/fixtures/items.ts
@@ -35,7 +35,10 @@ export const DEFAULT_FOLDER_ITEM: MockItem = {
     isPinned: false,
     showChatbox: false,
   },
-  memberships: [{ memberId: MEMBERS.BOB.id, permission: PermissionLevel.Read }],
+  memberships: [
+    { memberId: MEMBERS.BOB.id, permission: PermissionLevel.Read },
+    { memberId: MEMBERS.CEDRIC.id, permission: PermissionLevel.Write },
+  ],
 };
 
 export const ITEM_WITH_CHAT_BOX: MockItem = {

--- a/src/modules/item/Item.tsx
+++ b/src/modules/item/Item.tsx
@@ -328,6 +328,7 @@ const ItemContentWrapper = ({ item }: { item: ItemRecord }) => {
   const { data: itemTags } = useItemTags(item.id);
   const isItemHidden = isHidden(item, itemTags);
 
+  // An item the user has access to can be hidden (write, admin) so we hide it in player
   if (isItemHidden) {
     return null;
   }

--- a/src/modules/item/Item.tsx
+++ b/src/modules/item/Item.tsx
@@ -48,7 +48,6 @@ import {
 import { useCurrentMemberContext } from '@/contexts/CurrentMemberContext';
 import { isHidden, paginationContentFilter } from '@/utils/item';
 
-import HiddenWrapper from '../common/HiddenWrapper';
 import PinnedFolderItem from './PinnedFolderItem';
 
 const {
@@ -329,11 +328,10 @@ const ItemContentWrapper = ({ item }: { item: ItemRecord }) => {
   const { data: itemTags } = useItemTags(item.id);
   const isItemHidden = isHidden(item, itemTags);
 
-  return (
-    <HiddenWrapper itemId={item.id} hidden={isItemHidden}>
-      <ItemContent item={item} />
-    </HiddenWrapper>
-  );
+  if (isItemHidden) {
+    return null;
+  }
+  return <ItemContent item={item} />;
 };
 
 type Props = {


### PR DESCRIPTION
This PR:
- changes the display of hidden items. They are now __completely__ hidden even for Admins and writers

_Note:_ Since the hidden state is only known after we get the tags, the hidden items might quickly flash before they are hidden. If this is an issue, we could:
- wait for the tags
- send the tags together with the item response