### PR TITLE
fix: app max height

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@graasp/query-client": "3.9.0",
     "@graasp/sdk": "4.12.0",
     "@graasp/translations": "1.28.0",
-    "@graasp/ui": "github:graasp/graasp-ui#remove-maxheight-on-app",
+    "@graasp/ui": "4.19.3",
     "@mui/icons-material": "5.15.17",
     "@mui/lab": "5.0.0-alpha.170",
     "@mui/material": "5.15.17",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@graasp/query-client": "3.9.0",
     "@graasp/sdk": "4.12.0",
     "@graasp/translations": "1.28.0",
-    "@graasp/ui": "4.19.2",
+    "@graasp/ui": "github:graasp/graasp-ui#remove-maxheight-on-app",
     "@mui/icons-material": "5.15.17",
     "@mui/lab": "5.0.0-alpha.170",
     "@mui/material": "5.15.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,9 +1344,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/ui@github:graasp/graasp-ui#remove-maxheight-on-app":
-  version: 4.19.2
-  resolution: "@graasp/ui@https://github.com/graasp/graasp-ui.git#commit=c20230cd306ec64de2762e4b4ae393b908f9ed28"
+"@graasp/ui@npm:4.19.3":
+  version: 4.19.3
+  resolution: "@graasp/ui@npm:4.19.3"
   dependencies:
     "@ag-grid-community/client-side-row-model": "npm:31.3.2"
     "@ag-grid-community/react": "npm:^31.3.1"
@@ -1379,7 +1379,7 @@ __metadata:
     react-router-dom: ^6.11.0
     stylis: ^4.1.3
     stylis-plugin-rtl: ^2.1.1
-  checksum: 10/6eaaa3dbfe10023ebce3210289dba8d018526e78dfea7c3a93c407164b71294134ece7f1ea36521a1cfcfe95204a174471be8a426164fbf2755f9cdfcc020b31
+  checksum: 10/b725707ad4795fdc2b9b8a5981b0b40d2f33f60eab9b6c8fb4076d51ca9fb7dc0e157ca440f665c177a834ef4ba97c2838ebbcda3d03d41ab1368c47cfeb9b67
   languageName: node
   linkType: hard
 
@@ -6255,7 +6255,7 @@ __metadata:
     "@graasp/query-client": "npm:3.9.0"
     "@graasp/sdk": "npm:4.12.0"
     "@graasp/translations": "npm:1.28.0"
-    "@graasp/ui": "github:graasp/graasp-ui#remove-maxheight-on-app"
+    "@graasp/ui": "npm:4.19.3"
     "@mui/icons-material": "npm:5.15.17"
     "@mui/lab": "npm:5.0.0-alpha.170"
     "@mui/material": "npm:5.15.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,9 +1344,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graasp/ui@npm:4.19.2":
+"@graasp/ui@github:graasp/graasp-ui#remove-maxheight-on-app":
   version: 4.19.2
-  resolution: "@graasp/ui@npm:4.19.2"
+  resolution: "@graasp/ui@https://github.com/graasp/graasp-ui.git#commit=c20230cd306ec64de2762e4b4ae393b908f9ed28"
   dependencies:
     "@ag-grid-community/client-side-row-model": "npm:31.3.2"
     "@ag-grid-community/react": "npm:^31.3.1"
@@ -1379,7 +1379,7 @@ __metadata:
     react-router-dom: ^6.11.0
     stylis: ^4.1.3
     stylis-plugin-rtl: ^2.1.1
-  checksum: 10/d49857988ba4ea2ca195b7d8f8e01b97c670205049ec6db793144f7f305b1483cde3f5558733f8332d8ff16f49e803ed8b1bb8263463717ed2e64bcda71810af
+  checksum: 10/6eaaa3dbfe10023ebce3210289dba8d018526e78dfea7c3a93c407164b71294134ece7f1ea36521a1cfcfe95204a174471be8a426164fbf2755f9cdfcc020b31
   languageName: node
   linkType: hard
 
@@ -6255,7 +6255,7 @@ __metadata:
     "@graasp/query-client": "npm:3.9.0"
     "@graasp/sdk": "npm:4.12.0"
     "@graasp/translations": "npm:1.28.0"
-    "@graasp/ui": "npm:4.19.2"
+    "@graasp/ui": "github:graasp/graasp-ui#remove-maxheight-on-app"
     "@mui/icons-material": "npm:5.15.17"
     "@mui/lab": "npm:5.0.0-alpha.170"
     "@mui/material": "npm:5.15.17"


### PR DESCRIPTION
In this PR I update player with the new version of UI that contains the fix to not set a maxHeight of 70vh on the app iframe.

I deployed this to dev to test and it works as expected.