### PR TITLE
fix: eslint@v9 error with vite-plugin-checker

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,10 @@ export default ({ mode }: { mode: string }): UserConfigExport => {
       mode !== 'test'
         ? checker({
             typescript: true,
-            eslint: { lintCommand: 'eslint "./**/*.{ts,tsx}"' },
+            eslint: {
+              useFlatConfig: true,
+              lintCommand: 'eslint "./**/*.{ts,tsx}"',
+            },
             overlay: { initialIsOpen: false },
           })
         : undefined,


### PR DESCRIPTION
This fixes an issue where it was not possible to start the app.

The cause of the issue is with the move to the new eslint v9 flatconfigs.

We had to specify to `vite-plugin-checker` that we are using eslint flatConfig.
