### PR TITLE
fix: move page wrapper where the ids are known

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -7,7 +7,6 @@ import {
 import { buildContentPagePath, buildMainPath } from '@/config/paths';
 import {
   HOME_PAGE_PAGINATION_ID,
-  TREE_FALLBACK_RELOAD_BUTTON_ID,
   TREE_VIEW_ID,
   buildHomePaginationId,
   buildTreeItemClass,
@@ -109,12 +108,8 @@ describe('Internal navigation', () => {
     cy.get(`#${link.id}`).click();
 
     cy.url().should('contain', url);
-    // wait for page to stabilize
-    cy.wait(2000);
-    cy.get('h2').should('contain', target.name);
 
-    // since the tree view crashes, expect the reload button
-    cy.get(`#${TREE_FALLBACK_RELOAD_BUTTON_ID}`).click();
+    cy.get('h2').should('contain', target.name);
 
     cy.get(`#${TREE_VIEW_ID}`).should('contain', target.name);
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,56 +94,56 @@ export const App = (): JSX.Element => {
 
   return (
     <Routes>
-      <Route element={<PageWrapper fullscreen={fullscreen} />}>
-        <Route path={buildMainPath()}>
-          <Route index element={<RedirectToRootContentPage />} />
-          <Route path=":itemId">
-            <Route index element={<ItemPage />} />
-            <Route path={AUTO_LOGIN_PATH} element={<AutoLogin />} />
-          </Route>
+      <Route path={buildMainPath()}>
+        <Route index element={<RedirectToRootContentPage />} />
+        <Route path=":itemId" element={<PageWrapper fullscreen={fullscreen} />}>
+          <Route index element={<ItemPage />} />
+          <Route path={AUTO_LOGIN_PATH} element={<AutoLogin />} />
         </Route>
-        <Route
-          element={
-            // redirect to sign in if not signed in
-            <SignedInWrapper
+      </Route>
+      <Route
+        element={
+          // redirect to sign in if not signed in
+          <SignedInWrapper
+            currentAccount={currentAccount}
+            redirectionLink={buildSignInPath({
+              host: AUTHENTICATION_HOST,
+              redirectionUrl: window.location.href,
+            })}
+            onRedirect={() => {
+              // save current url for later redirection after sign in
+              saveUrlForRedirection(location.pathname, DOMAIN);
+            }}
+          >
+            <PreventGuestWrapper
+              id={PREVENT_GUEST_MESSAGE_ID}
               currentAccount={currentAccount}
-              redirectionLink={buildSignInPath({
-                host: AUTHENTICATION_HOST,
-                redirectionUrl: window.location.href,
-              })}
-              onRedirect={() => {
-                // save current url for later redirection after sign in
-                saveUrlForRedirection(location.pathname, DOMAIN);
-              }}
+              buttonText={t(PLAYER.GUEST_SIGN_OUT_BUTTON)}
+              onButtonClick={() => signOut()}
+              errorText={t(PLAYER.ERROR_MESSAGE)}
+              text={
+                <Trans
+                  t={t}
+                  i18nKey={PLAYER.GUEST_LIMITATION_TEXT}
+                  values={{
+                    name: currentAccount?.name,
+                  }}
+                  components={{ 1: <strong /> }}
+                />
+              }
             >
-              <PreventGuestWrapper
-                id={PREVENT_GUEST_MESSAGE_ID}
-                currentAccount={currentAccount}
-                buttonText={t(PLAYER.GUEST_SIGN_OUT_BUTTON)}
-                onButtonClick={() => signOut()}
-                errorText={t(PLAYER.ERROR_MESSAGE)}
-                text={
-                  <Trans
-                    t={t}
-                    i18nKey={PLAYER.GUEST_LIMITATION_TEXT}
-                    values={{
-                      name: currentAccount?.name,
-                    }}
-                    components={{ 1: <strong /> }}
-                  />
-                }
-              >
-                <Outlet />
-              </PreventGuestWrapper>
-            </SignedInWrapper>
-          }
-        >
+              <Outlet />
+            </PreventGuestWrapper>
+          </SignedInWrapper>
+        }
+      >
+        <Route element={<PageWrapper fullscreen={fullscreen} />}>
           <Route path={HOME_PATH} element={<HomePage />} />
         </Route>
-
-        {/* Default redirect  */}
-        <Route path="*" element={<Navigate to={HOME_PATH} />} />
       </Route>
+
+      {/* Default redirect  */}
+      <Route path="*" element={<Navigate to={HOME_PATH} />} />
     </Routes>
   );
 };


### PR DESCRIPTION
In this PR I fix the navigation crashing bug. 

This bug was caused by rendering the navigation higher in the hierarchy where we potentially did not have access to the `:itemId`. 
When moving the sidebar wrapper below where the itemId is defined we do not have a crash when moving between lessons with only the `/:rootId` path.

This is likely the bug that was encountered by many Safari users, as reported by @swouf.

close #886 
close #773 

